### PR TITLE
simplify: codebase-wide quality fixes (13 items)

### DIFF
--- a/backend/app/api/monitoring.py
+++ b/backend/app/api/monitoring.py
@@ -283,14 +283,22 @@ async def get_dashboard_metrics(
 ):
     """Get dashboard metrics"""
     from sqlalchemy import select, func
-    from app.models import Incident, MonitorStatus, IncidentStatus
+    from app.models import Monitor, Incident, MonitorStatus, IncidentStatus
 
-    # Count monitors by status
+    # Count monitors by status via DB aggregation
+    status_result = await db.execute(
+        select(Monitor.status, func.count(Monitor.id).label("count"))
+        .group_by(Monitor.status)
+    )
+    status_counts = {row.status: row.count for row in status_result}
+
+    monitors_up = status_counts.get(MonitorStatus.UP, 0)
+    monitors_down = status_counts.get(MonitorStatus.DOWN, 0)
+    monitors_degraded = status_counts.get(MonitorStatus.DEGRADED, 0)
+    total_monitors = sum(status_counts.values())
+
+    # Still fetch monitors for per-monitor uptime calculation
     monitors = await monitor_service.get_monitors(db)
-    total_monitors = len(monitors)
-    monitors_up = sum(1 for m in monitors if m.status == MonitorStatus.UP)
-    monitors_down = sum(1 for m in monitors if m.status == MonitorStatus.DOWN)
-    monitors_degraded = sum(1 for m in monitors if m.status == MonitorStatus.DEGRADED)
 
     # Count active incidents
     query = select(func.count()).select_from(Incident).where(

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.utils.database import get_db
 from app.utils.auth import get_current_active_user
-from app.services import TaskService, CommentService, DeleteResult
+from app.services import TaskService, CommentService, DeleteResult, AddLabelResult
 from app.models.task import CardPriority
 from app.api.websocket import broadcast_update
 from pydantic import BaseModel, ConfigDict, Field
@@ -403,12 +403,12 @@ async def attach_label_to_card(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Card or label not found"
         )
-    if result == "cross_board":
+    if result == AddLabelResult.CROSS_BOARD:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Label does not belong to the same board as the card"
         )
-    if result == "duplicate":
+    if result == AddLabelResult.DUPLICATE:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Label is already attached to this card"

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -25,9 +25,7 @@ class BoardResponse(BaseModel):
     description: Optional[str]
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ListCreate(BaseModel):
@@ -41,9 +39,7 @@ class ListResponse(BaseModel):
     name: str
     position: int
     created_at: datetime
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CardCreate(BaseModel):
@@ -92,9 +88,7 @@ class CardResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     labels: List[LabelResponse] = []
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ListWithCardsResponse(BaseModel):
@@ -104,9 +98,7 @@ class ListWithCardsResponse(BaseModel):
     position: int
     created_at: datetime
     cards: List[CardResponse] = []
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class BoardWithListsResponse(BaseModel):
@@ -116,9 +108,7 @@ class BoardWithListsResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
     lists: List[ListWithCardsResponse] = []
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ActivityResponse(BaseModel):
@@ -128,9 +118,7 @@ class ActivityResponse(BaseModel):
     entity_id: uuid.UUID
     details: Optional[str]
     timestamp: datetime
-
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class CommentCreate(BaseModel):

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -24,11 +24,17 @@ class ConnectionManager:
 
     async def broadcast(self, message: dict):
         message_str = json.dumps(message)
+        dead = []
         for connection in self.active_connections:
             try:
                 await connection.send_text(message_str)
             except Exception as e:
                 logger.error(f"Error broadcasting to websocket: {e}")
+                dead.append(connection)
+
+        # Remove dead connections
+        for connection in dead:
+            self.active_connections.remove(connection)
 
 manager = ConnectionManager()
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,6 +1,6 @@
-from app.services.task_service import TaskService, CommentService, DeleteResult
+from app.services.task_service import TaskService, CommentService, DeleteResult, AddLabelResult
 from app.services.monitor_service import MonitorService
 from app.services.alert_service import AlertService
 from app.services.audit_service import AuditService, AuditLog
 
-__all__ = ["TaskService", "CommentService", "DeleteResult", "MonitorService", "AlertService", "AuditService", "AuditLog"]
+__all__ = ["TaskService", "CommentService", "DeleteResult", "AddLabelResult", "MonitorService", "AlertService", "AuditService", "AuditLog"]

--- a/backend/app/services/monitor_service.py
+++ b/backend/app/services/monitor_service.py
@@ -186,17 +186,20 @@ class MonitorService:
 
         return check
 
-    async def handle_ssl_incident(self, db: AsyncSession, monitor: Monitor, status: MonitorStatus, ssl_expiry_days: Optional[int]):
-        """Handle incident creation and resolution for SSL monitors (no 3-failure wait)."""
-        # Check for existing open incident
+    async def _get_open_incident(self, db: AsyncSession, monitor_id: uuid.UUID) -> Optional[Incident]:
+        """Return the open (investigating/identified) incident for a monitor, or None."""
         query = select(Incident).where(
             and_(
-                Incident.monitor_id == monitor.id,
+                Incident.monitor_id == monitor_id,
                 Incident.status.in_([IncidentStatus.INVESTIGATING, IncidentStatus.IDENTIFIED])
             )
         )
         result = await db.execute(query)
-        existing_incident = result.scalar_one_or_none()
+        return result.scalar_one_or_none()
+
+    async def handle_ssl_incident(self, db: AsyncSession, monitor: Monitor, status: MonitorStatus, ssl_expiry_days: Optional[int]):
+        """Handle incident creation and resolution for SSL monitors (no 3-failure wait)."""
+        existing_incident = await self._get_open_incident(db, monitor.id)
 
         if status == MonitorStatus.DOWN:
             if not existing_incident:
@@ -245,15 +248,7 @@ class MonitorService:
         if monitor_id_str not in failure_counts:
             failure_counts[monitor_id_str] = 0
 
-        # Check for existing open incident
-        query = select(Incident).where(
-            and_(
-                Incident.monitor_id == monitor.id,
-                Incident.status.in_([IncidentStatus.INVESTIGATING, IncidentStatus.IDENTIFIED])
-            )
-        )
-        result = await db.execute(query)
-        existing_incident = result.scalar_one_or_none()
+        existing_incident = await self._get_open_incident(db, monitor.id)
 
         if status == MonitorStatus.DOWN:
             failure_counts[monitor_id_str] += 1

--- a/backend/app/services/monitor_service.py
+++ b/backend/app/services/monitor_service.py
@@ -242,23 +242,21 @@ class MonitorService:
 
     async def handle_incident(self, db: AsyncSession, monitor: Monitor, status: MonitorStatus):
         """Handle incident creation and resolution"""
-        monitor_id_str = str(monitor.id)
-
         # Initialize failure count if needed
-        if monitor_id_str not in failure_counts:
-            failure_counts[monitor_id_str] = 0
+        if monitor.id not in failure_counts:
+            failure_counts[monitor.id] = 0
 
         existing_incident = await self._get_open_incident(db, monitor.id)
 
         if status == MonitorStatus.DOWN:
-            failure_counts[monitor_id_str] += 1
+            failure_counts[monitor.id] += 1
 
             # Create incident after 3 consecutive failures
-            if failure_counts[monitor_id_str] >= 3 and not existing_incident:
+            if failure_counts[monitor.id] >= 3 and not existing_incident:
                 incident = Incident(
                     monitor_id=monitor.id,
                     title=f"{monitor.name} is down",
-                    description=f"Monitor {monitor.name} has failed {failure_counts[monitor_id_str]} consecutive checks",
+                    description=f"Monitor {monitor.name} has failed {failure_counts[monitor.id]} consecutive checks",
                     severity=IncidentSeverity.CRITICAL,
                     status=IncidentStatus.INVESTIGATING
                 )
@@ -267,7 +265,7 @@ class MonitorService:
                 logger.warning(f"Created incident for monitor {monitor.id}")
 
         elif status == MonitorStatus.UP:
-            failure_counts[monitor_id_str] = 0
+            failure_counts[monitor.id] = 0
 
             # Auto-resolve incident if exists
             if existing_incident:
@@ -313,17 +311,16 @@ class MonitorService:
         if not monitor or not monitor.enabled:
             return
 
-        monitor_id_str = str(monitor_id)
-        if monitor_id_str in active_monitors:
+        if monitor_id in active_monitors:
             return
 
         async def monitor_loop():
-            while monitor_id_str in active_monitors:
+            while monitor_id in active_monitors:
                 try:
                     async with AsyncSessionLocal() as loop_db:
                         fresh_monitor = await self.get_monitor(loop_db, monitor_id)
                         if fresh_monitor is None or not fresh_monitor.enabled:
-                            active_monitors.pop(monitor_id_str, None)
+                            active_monitors.pop(monitor_id, None)
                             logger.info(f"Monitor {monitor_id} deleted or disabled — stopping loop")
                             break
                         await self.execute_check(loop_db, fresh_monitor)
@@ -333,13 +330,12 @@ class MonitorService:
                     await asyncio.sleep(monitor.interval)
 
         task = asyncio.create_task(monitor_loop())
-        active_monitors[monitor_id_str] = task
+        active_monitors[monitor_id] = task
         logger.info(f"Started monitoring for {monitor_id}")
 
     async def stop_monitoring(self, monitor_id: uuid.UUID):
         """Stop monitoring loop for a monitor"""
-        monitor_id_str = str(monitor_id)
-        if monitor_id_str in active_monitors:
-            task = active_monitors.pop(monitor_id_str)
+        if monitor_id in active_monitors:
+            task = active_monitors.pop(monitor_id)
             task.cancel()
             logger.info(f"Stopped monitoring for {monitor_id}")

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -23,6 +23,13 @@ class AddLabelResult(str, enum.Enum):
 
 class TaskService:
     @staticmethod
+    async def _load_card_with_labels(db: AsyncSession, card_id: uuid.UUID) -> Card:
+        result = await db.execute(
+            select(Card).options(selectinload(Card.labels)).where(Card.id == card_id)
+        )
+        return result.scalar_one()
+
+    @staticmethod
     async def create_board(db: AsyncSession, name: str, description: Optional[str] = None, user_id: Optional[uuid.UUID] = None) -> Board:
         """Create a new board"""
         board = Board(name=name, description=description, user_id=user_id)
@@ -141,9 +148,7 @@ class TaskService:
         await db.commit()
 
         # Reload with labels eagerly loaded
-        card_query = select(Card).where(Card.id == card.id).options(selectinload(Card.labels))
-        result = await db.execute(card_query)
-        card = result.scalar_one()
+        card = await TaskService._load_card_with_labels(db, card.id)
 
         logger.info(f"Created card: {card.id} in list {list_id}")
         return card
@@ -165,9 +170,7 @@ class TaskService:
         await db.commit()
 
         # Reload with labels eagerly loaded
-        card_query = select(Card).where(Card.id == card_id).options(selectinload(Card.labels))
-        result = await db.execute(card_query)
-        card = result.scalar_one()
+        card = await TaskService._load_card_with_labels(db, card_id)
 
         logger.info(f"Moved card: {card_id} to list {new_list_id}")
         return card
@@ -186,9 +189,7 @@ class TaskService:
         card.updated_at = datetime.utcnow()
         await db.commit()
         # Reload with labels eagerly loaded
-        card_query = select(Card).where(Card.id == card_id).options(selectinload(Card.labels))
-        result = await db.execute(card_query)
-        card = result.scalar_one()
+        card = await TaskService._load_card_with_labels(db, card_id)
         logger.info(f"Updated card: {card_id}")
         return card
 
@@ -286,9 +287,7 @@ class TaskService:
         await db.commit()
 
         # Reload card with labels
-        card_query = select(Card).where(Card.id == card_id).options(selectinload(Card.labels))
-        card_result = await db.execute(card_query)
-        card = card_result.scalar_one()
+        card = await TaskService._load_card_with_labels(db, card_id)
 
         logger.info(f"Added label {label_id} to card {card_id}")
         return card

--- a/backend/app/services/task_service.py
+++ b/backend/app/services/task_service.py
@@ -16,6 +16,11 @@ class DeleteResult(enum.Enum):
     FORBIDDEN = "forbidden"
 
 
+class AddLabelResult(str, enum.Enum):
+    CROSS_BOARD = "cross_board"
+    DUPLICATE = "duplicate"
+
+
 class TaskService:
     @staticmethod
     async def create_board(db: AsyncSession, name: str, description: Optional[str] = None, user_id: Optional[uuid.UUID] = None) -> Board:
@@ -248,8 +253,8 @@ class TaskService:
     @staticmethod
     async def add_label_to_card(
         db: AsyncSession, card_id: uuid.UUID, label_id: uuid.UUID
-    ) -> Union[Card, str, None]:
-        """Attach a label to a card. Returns Card on success, 'cross_board' or 'duplicate' on error, None if not found."""
+    ) -> Union[Card, AddLabelResult, None]:
+        """Attach a label to a card. Returns Card on success, AddLabelResult on error, None if not found."""
         # Load card with its list
         card_query = select(Card).where(Card.id == card_id).options(
             selectinload(Card.list),
@@ -271,11 +276,11 @@ class TaskService:
 
         # Validate label belongs to the same board as the card
         if label.board_id != card.list.board_id:
-            return "cross_board"
+            return AddLabelResult.CROSS_BOARD
 
         # Check for duplicate
         if any(lbl.id == label_id for lbl in card.labels):
-            return "duplicate"
+            return AddLabelResult.DUPLICATE
 
         card.labels.append(label)
         await db.commit()

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,7 +6,8 @@ import { Navbar, Container, Nav, NavDropdown } from 'react-bootstrap'
 export default function Layout() {
   const navigate = useNavigate()
   const location = useLocation()
-  const { user, logout } = useAuthStore()
+  const user = useAuthStore((state) => state.user)
+  const logout = useAuthStore((state) => state.logout)
 
   const handleLogout = () => {
     logout()

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -71,6 +71,9 @@ export function useWebSocket(
       setConnected(false)
       wsRef.current = null
       if (!unmountedRef.current) {
+        if (reconnectTimerRef.current !== null) {
+          clearTimeout(reconnectTimerRef.current)
+        }
         reconnectTimerRef.current = setTimeout(() => {
           reconnectDelayRef.current = Math.min(
             reconnectDelayRef.current * 2,

--- a/frontend/src/lib/statusUtils.tsx
+++ b/frontend/src/lib/statusUtils.tsx
@@ -1,0 +1,34 @@
+import { CheckCircle, XCircle, AlertTriangle, Activity } from 'lucide-react'
+import type { ReactElement } from 'react'
+
+/**
+ * Returns a Lucide icon element for a given monitor status.
+ * @param status - Monitor status string ('up' | 'down' | 'degraded' | other)
+ * @param size - Tailwind size class for the icon (default: 'w-5 h-5')
+ */
+export function getStatusIcon(status: string, size = 'w-5 h-5'): ReactElement {
+  switch (status) {
+    case 'up':
+      return <CheckCircle className={`${size} text-green-500`} />
+    case 'down':
+      return <XCircle className={`${size} text-red-500`} />
+    case 'degraded':
+      return <AlertTriangle className={`${size} text-yellow-500`} />
+    default:
+      return <Activity className={`${size} text-gray-400`} />
+  }
+}
+
+/**
+ * Returns Tailwind badge classes for a given monitor status.
+ * @param status - Monitor status string ('up' | 'down' | 'degraded' | 'paused' | other)
+ */
+export function getStatusBadgeClass(status: string): string {
+  const styles: Record<string, string> = {
+    up: 'bg-green-100 text-green-800',
+    down: 'bg-red-100 text-red-800',
+    degraded: 'bg-yellow-100 text-yellow-800',
+    paused: 'bg-gray-100 text-gray-800',
+  }
+  return styles[status] ?? styles.paused
+}

--- a/frontend/src/pages/Agents.tsx
+++ b/frontend/src/pages/Agents.tsx
@@ -7,6 +7,29 @@ type SpecType = 'general' | 'user_story' | 'bdd'
 type TestType = 'unit' | 'integration' | 'bdd'
 type DevType = 'api' | 'service' | 'general' | 'model' | 'util'
 
+function createAgentHandler(
+  apiCall: () => Promise<string>,
+  setResult: (result: string) => void,
+  setLoading: (loading: boolean) => void,
+  setError: (error: string | null) => void,
+  errorMessage: string,
+  logLabel: string,
+) {
+  return async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await apiCall()
+      setResult(result)
+    } catch (err) {
+      console.error(logLabel, err)
+      setError(errorMessage)
+    } finally {
+      setLoading(false)
+    }
+  }
+}
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
 
@@ -51,50 +74,47 @@ export default function Agents() {
 
   const handleGenerateSpec = async () => {
     if (!requirements.trim()) return
-    setSpecLoading(true)
-    setSpecError(null)
-    try {
-      const res = await agents.spec({ requirements: requirements.trim(), type: specType })
-      const spec = res.data.specification
-      setSpecification(spec)
-      setTestSpec(spec)
-      setDevSpec(spec)
-    } catch (err) {
-      console.error('Spec agent error:', err)
-      setSpecError('Failed to generate specification. Please try again.')
-    } finally {
-      setSpecLoading(false)
-    }
+    await createAgentHandler(
+      async () => {
+        const res = await agents.spec({ requirements: requirements.trim(), type: specType })
+        return res.data.specification
+      },
+      (spec) => { setSpecification(spec); setTestSpec(spec); setDevSpec(spec) },
+      setSpecLoading,
+      setSpecError,
+      'Failed to generate specification. Please try again.',
+      'Spec agent error:',
+    )()
   }
 
   const handleGenerateTests = async () => {
     if (!testSpec.trim()) return
-    setTestLoading(true)
-    setTestError(null)
-    try {
-      const res = await agents.test({ specification: testSpec.trim(), type: testType })
-      setTestCode(res.data.test_code)
-    } catch (err) {
-      console.error('Test agent error:', err)
-      setTestError('Failed to generate tests. Please try again.')
-    } finally {
-      setTestLoading(false)
-    }
+    await createAgentHandler(
+      async () => {
+        const res = await agents.test({ specification: testSpec.trim(), type: testType })
+        return res.data.test_code
+      },
+      setTestCode,
+      setTestLoading,
+      setTestError,
+      'Failed to generate tests. Please try again.',
+      'Test agent error:',
+    )()
   }
 
   const handleGenerateCode = async () => {
     if (!devSpec.trim()) return
-    setDevLoading(true)
-    setDevError(null)
-    try {
-      const res = await agents.dev({ specification: devSpec.trim(), type: devType })
-      setDevCode(res.data.code)
-    } catch (err) {
-      console.error('Dev agent error:', err)
-      setDevError('Failed to generate code. Please try again.')
-    } finally {
-      setDevLoading(false)
-    }
+    await createAgentHandler(
+      async () => {
+        const res = await agents.dev({ specification: devSpec.trim(), type: devType })
+        return res.data.code
+      },
+      setDevCode,
+      setDevLoading,
+      setDevError,
+      'Failed to generate code. Please try again.',
+      'Dev agent error:',
+    )()
   }
 
   const handleRunPipeline = async () => {

--- a/frontend/src/pages/Monitoring.tsx
+++ b/frontend/src/pages/Monitoring.tsx
@@ -142,9 +142,9 @@ export default function Monitoring() {
 
   const triggerCheckMutation = useMutation({
     mutationFn: (id: string) => monitors.check(id),
-    onSuccess: () => {
+    onSuccess: (_, monitorId: string) => {
       queryClient.invalidateQueries({ queryKey: ['monitors'] })
-      queryClient.invalidateQueries({ queryKey: ['uptime'] })
+      queryClient.invalidateQueries({ queryKey: ['uptime', monitorId] })
     },
     onError: (error) => {
       console.error('Failed to trigger check:', error)

--- a/frontend/src/pages/Monitoring.tsx
+++ b/frontend/src/pages/Monitoring.tsx
@@ -1,8 +1,9 @@
 import { useState, useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Plus, Activity, CheckCircle, XCircle, AlertTriangle, Brain, ChevronDown, ChevronUp, Wifi } from 'lucide-react'
+import { Plus, Brain, ChevronDown, ChevronUp, Wifi } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import { monitors, incidents } from '../lib/api'
+import { getStatusIcon, getStatusBadgeClass } from '../lib/statusUtils'
 import { useWebSocket } from '../hooks/useWebSocket'
 import type { WsMessage } from '../hooks/useWebSocket'
 import type { Incident, AnalysisResult, Monitor } from '../types'
@@ -149,29 +150,6 @@ export default function Monitoring() {
       console.error('Failed to trigger check:', error)
     },
   })
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'up':
-        return <CheckCircle className="w-5 h-5 text-green-500" />
-      case 'down':
-        return <XCircle className="w-5 h-5 text-red-500" />
-      case 'degraded':
-        return <AlertTriangle className="w-5 h-5 text-yellow-500" />
-      default:
-        return <Activity className="w-5 h-5 text-gray-400" />
-    }
-  }
-
-  const getStatusBadge = (status: string) => {
-    const styles = {
-      up: 'bg-green-100 text-green-800',
-      down: 'bg-red-100 text-red-800',
-      degraded: 'bg-yellow-100 text-yellow-800',
-      paused: 'bg-gray-100 text-gray-800',
-    }
-    return styles[status as keyof typeof styles] || styles.paused
-  }
 
   const getSeverityBadge = (severity: string) => {
     const styles: Record<string, string> = {
@@ -389,7 +367,7 @@ export default function Monitoring() {
                   </div>
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap">
-                  <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusBadge(monitor.status)}`}>
+                  <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusBadgeClass(monitor.status)}`}>
                     {monitor.status}
                   </span>
                 </td>

--- a/frontend/src/pages/Monitoring.tsx
+++ b/frontend/src/pages/Monitoring.tsx
@@ -187,7 +187,7 @@ export default function Monitoring() {
       const res = await incidents.analyzeWithAI(incidentId, state.analysisType)
       setIncidentAnalysis((prev) => ({
         ...prev,
-        [incidentId]: { ...prev[incidentId], isPending: false, result: res.data },
+        [incidentId]: { ...(prev[incidentId] ?? DEFAULT_ANALYSIS_STATE), isPending: false, result: res.data },
       }))
     } catch (err) {
       const message =
@@ -195,7 +195,7 @@ export default function Monitoring() {
       setIncidentAnalysis((prev) => ({
         ...prev,
         [incidentId]: {
-          ...prev[incidentId],
+          ...(prev[incidentId] ?? DEFAULT_ANALYSIS_STATE),
           isPending: false,
           error: message,
         },

--- a/frontend/src/pages/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
-import { CheckCircle, XCircle, AlertTriangle, Clock } from 'lucide-react'
 import { dashboard } from '../lib/api'
+import { getStatusIcon, getStatusBadgeClass } from '../lib/statusUtils'
 import { format } from 'date-fns'
 
 export default function StatusPage() {
@@ -9,19 +9,6 @@ export default function StatusPage() {
     queryFn: () => dashboard.statusPage().then((res) => res.data),
     refetchInterval: 30000, // Refetch every 30 seconds
   })
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'up':
-        return <CheckCircle className="w-6 h-6 text-green-500" />
-      case 'down':
-        return <XCircle className="w-6 h-6 text-red-500" />
-      case 'degraded':
-        return <AlertTriangle className="w-6 h-6 text-yellow-500" />
-      default:
-        return <Clock className="w-6 h-6 text-gray-400" />
-    }
-  }
 
   const getOverallStatus = () => {
     const monitors = statusData?.monitors || []
@@ -65,7 +52,7 @@ export default function StatusPage() {
               <div key={monitor.name} className="px-6 py-4 hover:bg-gray-50">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center flex-1">
-                    {getStatusIcon(monitor.status)}
+                    {getStatusIcon(monitor.status, 'w-6 h-6')}
                     <div className="ml-4">
                       <div className="text-sm font-medium text-gray-900">
                         {monitor.name}
@@ -76,11 +63,7 @@ export default function StatusPage() {
                     </div>
                   </div>
                   <div className="text-right">
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                      monitor.status === 'up' ? 'bg-green-100 text-green-800' :
-                      monitor.status === 'down' ? 'bg-red-100 text-red-800' :
-                      'bg-yellow-100 text-yellow-800'
-                    }`}>
+                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(monitor.status)}`}>
                       {monitor.status.toUpperCase()}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

- **Backend (7 fixes):** Remove dead WebSocket connections; extract `_get_open_incident()` and `_load_card_with_labels()` helpers; drop redundant `str()` UUID conversions; standardize Pydantic v2 `model_config`; replace magic strings with `AddLabelResult` enum; batch monitor status counts via DB aggregation
- **Frontend (6 fixes):** Extract shared `statusUtils.ts`; guard unsafe `undefined` spread in analysis state; fix WebSocket reconnect timer leak; consolidate copy-paste agent handlers with factory function; narrow uptime query invalidation to deleted monitor; use Zustand selectors in Layout

## Test Plan
- [x] 222 backend tests pass (`uv run pytest tests/`)
- [x] Frontend builds clean (`npm run build` — no errors)
- [ ] Manual smoke test: dashboard, monitoring page, task board, agents page

🤖 Generated with [Claude Code](https://claude.com/claude-code)